### PR TITLE
fix autocomplete arrow down highlight

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -61,9 +61,13 @@ class Autocomplete extends Component {
     if (!this.state.menu) {
       return
     }
-    this.open(() => {
-      this.state.menu.changeHighlighedIndex(amount)
-    })
+    if (this.state.isOpen) {
+      this.open(() => {
+        this.state.menu.changeHighlighedIndex(amount)
+      })
+    } else {
+      this.highlightIndex(this.state.menu.props.defaultHighlightedIndex)
+    }
   }
 
   highlightIndex = index => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Fixes https://github.com/paypal/react-autocompletely/issues/31
<!-- Why are these changes necessary? -->
**Why**:
First arrow down event was not respecting defaultHighlightedIndex prop.
<!-- How were these changes implemented? -->
**How**:
Use defaultHighlightedIndex prop when menu first opens .
<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
