### PR TITLE
feat(api): only return render prop from Menu component

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ This is called with an object with the properties listed below:
 
 ### Autocomplete.Menu
 
-This component allows you to render the items based on the user input. It
-renders a `div` with another `div` for your items and a `div` for the menu
-status (for accessibility purposes)
+This component allows you to render the items based on the user input. It must
+return a single child. It will also render a `div` to the end of the
+document for the menu status (for accessibility purposes).
 
 #### defaultHighlightedIndex
 
@@ -136,7 +136,7 @@ This is the initial index to highlight when the menu first opens.
 
 > `function({ resultCount, highlightedItem, getInputValue})` | default messages provided in English
 
-This function is passed by `Menu` as props to the `MenuStatus` component nested within and allows you to create your own assertive ARIA statuses. 
+This function is passed by `Menu` as props to the `MenuStatus` component nested within and allows you to create your own assertive ARIA statuses.
 
 A default `getA11yStatusMessage` function is provided that will check `resultCount` and return "No results." or if there are results but no item is highlighted, "`resultCount` results are available, use up and down arrow keys to navigate."  If an item is highlighted it will run `getInputValue(highlightedItem)` and display the value of the `highlightedItem`.  
 

--- a/examples/pages/apollo/index.js
+++ b/examples/pages/apollo/index.js
@@ -35,9 +35,9 @@ function ApolloAutocomplete() {
     <Autocomplete onChange={item => alert(item)}>
       <Autocomplete.Input />
       <Autocomplete.Menu>
-        {({inputValue, selectedItem, highlightedIndex}) => (
+        {({inputValue, selectedItem, highlightedIndex, isOpen}) => (
           <ApolloAutocompleteMenuWithData
-            {...{inputValue, selectedItem, highlightedIndex}}
+            {...{inputValue, selectedItem, highlightedIndex, isOpen}}
           />
         )}
       </Autocomplete.Menu>
@@ -49,7 +49,11 @@ function ApolloAutocompleteMenu({
   data: {allColors, loading},
   selectedItem,
   highlightedIndex,
+  isOpen,
 }) {
+  if (!isOpen) {
+    return null
+  }
   if (loading) {
     return <div>Loading...</div>
   }

--- a/examples/pages/axios-request/index.js
+++ b/examples/pages/axios-request/index.js
@@ -44,9 +44,9 @@ class AxiosAutocomplete extends Component {
           }}
         />
         <Autocomplete.Menu>
-          {({inputValue, selectedItem, highlightedIndex}) => {
+          {({inputValue, selectedItem, highlightedIndex, isOpen}) => {
             // prettier-ignore
-            return this.state.items.map((item, index) => (
+            return isOpen && <div>{this.state.items.map((item, index) => (
               <Autocomplete.Item
                 value={item}
                 index={index}
@@ -58,7 +58,7 @@ class AxiosAutocomplete extends Component {
               >
                 {item}
               </Autocomplete.Item>
-            ))
+            ))}</div>
           }}
         </Autocomplete.Menu>
       </Autocomplete>

--- a/examples/pages/basic/index.js
+++ b/examples/pages/basic/index.js
@@ -109,21 +109,27 @@ function BasicAutocomplete({items, onChange}) {
     <Autocomplete onChange={onChange}>
       <Input placeholder="Favorite color ?" />
       <Autocomplete.Menu style={{border: '1px solid rgba(34,36,38,.15)'}}>
-        {({inputValue, selectedItem, highlightedIndex}) =>
-          // prettier is doing weeeeird things to this
-          // prettier-ignore
-          items.filter(i => !inputValue || i.toLowerCase().includes(inputValue.toLowerCase()))
-            .map((item, index) => (
-              <Item
-                value={item}
-                index={index}
-                key={item}
-                highlightedIndex={highlightedIndex}
-                selectedItem={selectedItem}
-              >
-                {item}
-              </Item>
-            ))}
+        {({isOpen, inputValue, selectedItem, highlightedIndex}) =>
+          isOpen &&
+          <div>
+            {items
+              .filter(
+                i =>
+                  !inputValue ||
+                  i.toLowerCase().includes(inputValue.toLowerCase()),
+              )
+              .map((item, index) =>
+                (<Item
+                  value={item}
+                  index={index}
+                  key={item}
+                  highlightedIndex={highlightedIndex}
+                  selectedItem={selectedItem}
+                >
+                  {item}
+                </Item>),
+              )}
+          </div>}
       </Autocomplete.Menu>
     </Autocomplete>
   )

--- a/examples/pages/react-instantsearch/index.js
+++ b/examples/pages/react-instantsearch/index.js
@@ -10,20 +10,24 @@ function RawAutoComplete({refine, hits}) {
     <Autocomplete onChange={item => alert(JSON.stringify(item))}>
       <Autocomplete.Input onChange={e => refine(e.target.value)} />
       <Autocomplete.Menu>
-        {({selectedItem, highlightedIndex}) =>
-          hits.map((item, index) =>
-            (<Autocomplete.Item
-              value={item}
-              index={index}
-              key={item.objectID}
-              style={{
-                backgroundColor: highlightedIndex === index ? 'gray' : 'white',
-                fontWeight: selectedItem === item ? 'bold' : 'normal',
-              }}
-            >
-              <Highlight attributeName="name" hit={item} tagName="mark" />
-            </Autocomplete.Item>),
-          )}
+        {({selectedItem, highlightedIndex, isOpen}) =>
+          isOpen &&
+          <div>
+            {hits.map((item, index) =>
+              (<Autocomplete.Item
+                value={item}
+                index={index}
+                key={item.objectID}
+                style={{
+                  backgroundColor:
+                    highlightedIndex === index ? 'gray' : 'white',
+                  fontWeight: selectedItem === item ? 'bold' : 'normal',
+                }}
+              >
+                <Highlight attributeName="name" hit={item} tagName="mark" />
+              </Autocomplete.Item>),
+            )}
+          </div>}
       </Autocomplete.Menu>
     </Autocomplete>
   )

--- a/examples/pages/react-popper/index.js
+++ b/examples/pages/react-popper/index.js
@@ -53,8 +53,9 @@ class ReactPopperAutocomplete extends PureComponent {
               <Autocomplete.Input />
             </Target>
             <Autocomplete.Menu>
-              {({inputValue, selectedItem, highlightedIndex}) =>
-                (<Popper
+              {({inputValue, selectedItem, highlightedIndex, isOpen}) =>
+                isOpen &&
+                <Popper
                   placement={this.state.selected}
                   style={{backgroundColor: 'orange'}}
                 >
@@ -80,7 +81,7 @@ class ReactPopperAutocomplete extends PureComponent {
                         {item}
                       </Autocomplete.Item>),
                     )}
-                </Popper>)}
+                </Popper>}
             </Autocomplete.Menu>
           </Autocomplete>
         </Manager>

--- a/examples/pages/semantic-ui/index.js
+++ b/examples/pages/semantic-ui/index.js
@@ -104,10 +104,7 @@ const Input = glamorous(Autocomplete.Input, {
       : null,
 )
 
-const Menu = glamorous(Autocomplete.Menu, {
-  rootEl: 'div',
-  forwardProps: ['defaultHighlightedIndex'],
-})({
+const Menu = glamorous.div({
   maxHeight: '20rem',
   overflowY: 'auto',
   overflowX: 'hidden',
@@ -170,10 +167,12 @@ function SemanticUIAutocomplete() {
               </ControllerButton>}
           </Div>)}
       </Autocomplete.Controller>
-      <Menu defaultHighlightedIndex={0}>
-        {({inputValue, highlightedIndex, selectedItem}) =>
-          // prettier-ignore
-          (inputValue ? advancedFilter(items, inputValue) : items)
+      <Autocomplete.Menu defaultHighlightedIndex={0}>
+        {({inputValue, highlightedIndex, selectedItem, isOpen}) =>
+          isOpen &&
+          <Menu>
+            {// prettier-ignore
+            (inputValue ? advancedFilter(items, inputValue) : items)
             .map((item, index) => (
               <Item
                 value={item}
@@ -185,7 +184,8 @@ function SemanticUIAutocomplete() {
                 {item.name}
               </Item>
             ))}
-      </Menu>
+          </Menu>}
+      </Autocomplete.Menu>
     </Autocomplete>
   )
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "test": "nps test",
     "precommit": "lint-staged && opt --in pre-commit --exec \"npm start validate\""
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "keywords": [],
   "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
   "license": "MIT",
@@ -21,6 +23,7 @@
   },
   "peerDependencies": {
     "react": ">=15",
+    "react-dom": ">=15",
     "prop-types": ">=15"
   },
   "devDependencies": {

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -8,19 +8,15 @@ function BasicAutocomplete() {
     <Autocomplete onChange={() => {}}>
       <Autocomplete.Input />
       <Autocomplete.Menu>
-        {() =>
-          // prettier is doing weeeeird things to this
-          // prettier-ignore
-          items
-            .map((item, index) => (
-              <Autocomplete.Item
-                value={item}
-                index={index}
-                key={item}
-              >
+        {({isOpen}) =>
+          isOpen &&
+          <div>
+            {items.map((item, index) =>
+              (<Autocomplete.Item value={item} index={index} key={item}>
                 {item}
-              </Autocomplete.Item>
-            ))}
+              </Autocomplete.Item>),
+            )}
+          </div>}
       </Autocomplete.Menu>
     </Autocomplete>
   )

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -6,14 +6,12 @@ import Controller from './controller'
 import Input from './input'
 import Item from './item'
 import Menu from './menu'
-import MenuStatus from './menu-status'
 import {AUTOCOMPLETE_CONTEXT} from './constants'
 import {cbToCb, compose} from './utils'
 
 class Autocomplete extends Component {
   static Input = Input
   static Menu = Menu
-  static MenuStatus = MenuStatus
   static Item = Item
   static Controller = Controller
   static childContextTypes = {

--- a/src/controller.js
+++ b/src/controller.js
@@ -17,9 +17,7 @@ class Controller extends Component {
   }
 
   render() {
-    return this.props.children(
-      this.autocomplete.getControllerStateAndHelpers(),
-    )
+    return this.props.children(this.autocomplete.getControllerStateAndHelpers())
   }
 }
 

--- a/src/menu-status.js
+++ b/src/menu-status.js
@@ -1,14 +1,9 @@
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 
-import {MENU_CONTEXT} from './constants'
 import {debounce} from './utils'
 
 class MenuStatus extends Component {
-  static contextTypes = {
-    [MENU_CONTEXT]: PropTypes.object.isRequired,
-  }
-
   static defaultProps = {
     getA11yStatusMessage({resultCount, highlightedItem, getInputValue}) {
       if (!resultCount) {
@@ -23,14 +18,16 @@ class MenuStatus extends Component {
   }
 
   static propTypes = {
+    getA11yStatusMessage: PropTypes.func,
+    getInputValue: PropTypes.func,
+    getItemFromIndex: PropTypes.func,
     highlightedIndex: PropTypes.number,
     inputValue: PropTypes.string,
-    getA11yStatusMessage: PropTypes.func,
+    resultCount: PropTypes.number,
   }
 
   constructor(props, context) {
     super(props, context)
-    this.menu = this.context[MENU_CONTEXT]
     this.updateStatus = debounce(this.updateStatus, 200)
   }
   // have to do this because updateStatus is debounced
@@ -41,13 +38,8 @@ class MenuStatus extends Component {
     if (!this._isMounted) {
       return
     }
-    const {
-      items = [],
-      getItemFromIndex,
-      autocomplete: {getInputValue},
-    } = this.menu
+    const {resultCount, getItemFromIndex, getInputValue} = this.props
     const {statuses} = this.state
-    const resultCount = items.length
     const itemInstance = getItemFromIndex(highlightedIndex) || {
       props: {},
     }
@@ -77,13 +69,11 @@ class MenuStatus extends Component {
 
   componentDidMount() {
     this._isMounted = true
-    this.menu.emitter.on('changeHighlighedIndex', this.updateStatus)
     this.updateStatus()
   }
 
   componentWillUnmount() {
     this._isMounted = false
-    this.menu.emitter.off('changeHighlighedIndex', this.updateStatus)
   }
 
   renderStatus = (status, index) => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
This allows users to always render the menu similar to the option here in [react-autosuggest](https://github.com/moroshko/react-autosuggest#alwaysRenderSuggestionsProp). It also keeps a clean DOM by rendering the status to the end of the document as well as switches `children` function props to be called `render` for better API clarity.
<!-- Why are these changes necessary? -->
**Why**:
This will allow more complex menus and animations to be made by giving the user full control over rendering the `Menu` component. It's a little more work to hook `isOpen` up, but worth the benefit in my opinion. Plus you're already pulling things like `selectedItem` and `highlightedIndex` off.

I switched the `children` prop to `render` to follow conventions similar to React Router. After implementing just a returned `children` function, it felt weird that it was called "children" when it wasn't really returning any children. I can change this back, just let me know. I figured I'd see how you felt and then could revert if necessary 😇 
<!-- How were these changes implemented? -->
**How**:
I moved the `MenuStatus` into pretty much a small portal that renders the status to the end of the document so we can keep a clean DOM and simple API for the `Menu` component. 
<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
I'd love to hear your thoughts on this 🙂 I'll need to update the other examples if you are ok with these changes. It's a lot of moving parts for the `Menu` component, but I think it will allow for a little more flexibility.

This was the inspiration for this:
![image](https://user-images.githubusercontent.com/2762082/28701978-d3ab0ec6-730e-11e7-9310-ac1f7d96a822.png)
We need more control over the menu's rendering in a situation like this since the input is grouped alongside the items.