### PR TITLE
feat(component): added Button component to control Menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ This is called with an object with the properties listed below:
 | `selectItemAtIndex`     | `function(index: number)`  | selects the item at the given index                                                                              |
 | `selectHighlightedItem` | `function()`               | selects the item that is currently highlighted                                                                   |
 
+### Autocomplete.Button
+
+This component renders a `button` tag and allows you to toggle the `Menu` component. It will also apply all of the proper ARIA attributes.
+
 ### Autocomplete.Menu
 
 This component allows you to render the items based on the user input. It must

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ This is called with an object with the properties listed below:
 
 ### Autocomplete.Button
 
-This component renders a `button` tag and allows you to toggle the `Menu` component. It will also apply all of the proper ARIA attributes.
+This component renders a `button` tag and allows you to toggle the `Menu` component. You can definitely build something like this yourself (all of the available APIs are exposed to you via the `Controller`), but this is nice because it will also apply all of the proper ARIA attributes.
 
 ### Autocomplete.Menu
 

--- a/examples/pages/semantic-ui/index.js
+++ b/examples/pages/semantic-ui/index.js
@@ -120,7 +120,7 @@ const Menu = glamorous.div({
   borderStyle: 'solid',
 })
 
-const ControllerButton = glamorous.button({
+const ControllerButton = glamorous(Autocomplete.Button)({
   backgroundColor: 'transparent',
   border: 'none',
   position: 'absolute',
@@ -145,18 +145,23 @@ function SemanticUIAutocomplete() {
     >
       <Autocomplete.Controller>
         {({isOpen, toggleMenu, clearSelection, selectedItem}) =>
-          (<Div
-            position="relative"
-            css={{display: 'flex', paddingRight: '1.75em'}}
-          >
+          (<Div position="relative" css={{paddingRight: '1.75em'}}>
             <Input
               getValue={i => i.name}
               isOpen={isOpen}
               placeholder="Enter some info"
             />
-            <Autocomplete.Button>
-              <ArrowIcon isOpen={isOpen} />
-            </Autocomplete.Button>
+            {selectedItem
+              ? <ControllerButton
+                css={{paddingTop: 4}}
+                onClick={clearSelection}
+                aria-label="clear selection"
+                >
+                <XIcon />
+              </ControllerButton>
+              : <ControllerButton>
+                <ArrowIcon isOpen={isOpen} />
+              </ControllerButton>}
           </Div>)}
       </Autocomplete.Controller>
       <Autocomplete.Menu defaultHighlightedIndex={0}>

--- a/examples/pages/semantic-ui/index.js
+++ b/examples/pages/semantic-ui/index.js
@@ -145,26 +145,18 @@ function SemanticUIAutocomplete() {
     >
       <Autocomplete.Controller>
         {({isOpen, toggleMenu, clearSelection, selectedItem}) =>
-          (<Div position="relative" css={{paddingRight: '1.75em'}}>
+          (<Div
+            position="relative"
+            css={{display: 'flex', paddingRight: '1.75em'}}
+          >
             <Input
               getValue={i => i.name}
               isOpen={isOpen}
               placeholder="Enter some info"
             />
-            {selectedItem
-              ? <ControllerButton
-                css={{paddingTop: 4}}
-                onClick={clearSelection}
-                aria-label="clear selection"
-                >
-                <XIcon />
-              </ControllerButton>
-              : <ControllerButton
-                onClick={toggleMenu}
-                aria-label={isOpen ? 'close menu' : 'open menu'}
-                >
-                <ArrowIcon isOpen={isOpen} />
-              </ControllerButton>}
+            <Autocomplete.Button>
+              <ArrowIcon isOpen={isOpen} />
+            </Autocomplete.Button>
           </Div>)}
       </Autocomplete.Controller>
       <Autocomplete.Menu defaultHighlightedIndex={0}>

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -2,6 +2,7 @@ import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import mitt from 'mitt'
 
+import Button from './button'
 import Controller from './controller'
 import Input from './input'
 import Item from './item'
@@ -10,10 +11,11 @@ import {AUTOCOMPLETE_CONTEXT} from './constants'
 import {cbToCb, compose} from './utils'
 
 class Autocomplete extends Component {
-  static Input = Input
-  static Menu = Menu
-  static Item = Item
+  static Button = Button
   static Controller = Controller
+  static Input = Input
+  static Item = Item
+  static Menu = Menu
   static childContextTypes = {
     [AUTOCOMPLETE_CONTEXT]: PropTypes.object.isRequired,
   }

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -80,6 +80,7 @@ class Autocomplete extends Component {
   }
 
   clearSelection = () => {
+    this.emitter.emit('menu:close')
     this.setState(
       {
         selectedItem: null,
@@ -152,6 +153,7 @@ class Autocomplete extends Component {
   }
 
   reset = () => {
+    this.emitter.emit('menu:close')
     this.setState(
       ({selectedItem}) => ({
         isOpen: false,
@@ -180,6 +182,8 @@ class Autocomplete extends Component {
       }
       if (nextIsOpen) {
         this.emitter.emit('menu:open')
+      } else {
+        this.emitter.emit('menu:close')
       }
       return {isOpen: nextIsOpen}
     }, cbToCb(cb))

--- a/src/button.js
+++ b/src/button.js
@@ -1,0 +1,92 @@
+import React, {Component} from 'react'
+import PropTypes from 'prop-types'
+
+import {AUTOCOMPLETE_CONTEXT} from './constants'
+import {compose} from './utils'
+
+class Button extends Component {
+  static contextTypes = {
+    [AUTOCOMPLETE_CONTEXT]: PropTypes.object.isRequired,
+  }
+
+  static propTypes = {
+    disabled: PropTypes.bool,
+    onKeyDown: PropTypes.func,
+    onClick: PropTypes.func,
+  }
+
+  constructor(props, context) {
+    super(props, context)
+    this.autocomplete = this.context[AUTOCOMPLETE_CONTEXT]
+    this.handleKeyDown = compose(this.handleKeyDown, props.onKeyDown)
+    this.handleClick = compose(this.handleClick, props.onClick)
+  }
+
+  keyDownHandlers = {
+    ArrowDown(event) {
+      event.preventDefault()
+      const amount = event.shiftKey ? 5 : 1
+      this.autocomplete.moveHighlightedIndex(amount)
+    },
+
+    ArrowUp(event) {
+      event.preventDefault()
+      const amount = event.shiftKey ? -5 : -1
+      this.autocomplete.moveHighlightedIndex(amount)
+    },
+
+    Enter(event) {
+      event.preventDefault()
+      if (this.autocomplete.state.isOpen) {
+        this.autocomplete.selectHighlightedItem()
+      } else {
+        this.autocomplete.open()
+      }
+    },
+
+    Escape(event) {
+      event.preventDefault()
+      this.autocomplete.reset()
+    },
+
+    ' '(event) {
+      event.preventDefault()
+      this.autocomplete.toggleMenu()
+    },
+  }
+
+  handleKeyDown = event => {
+    if (event.key && this.keyDownHandlers[event.key]) {
+      this.keyDownHandlers[event.key].call(this, event)
+    }
+  }
+
+  handleClick = event => {
+    event.preventDefault()
+    this.autocomplete.toggleMenu()
+  }
+
+  focusButton = () => {
+    this._buttonNode.focus()
+  }
+
+  render() {
+    const {disabled, ...rest} = this.props
+    const {isOpen} = this.autocomplete.state
+    return (
+      <button
+        role="button"
+        tabIndex={disabled ? '' : '0'}
+        aria-haspopup={true}
+        aria-expanded={isOpen}
+        aria-disabled={disabled}
+        {...rest}
+        onKeyDown={this.handleKeyDown}
+        onClick={this.handleClick}
+        ref={node => (this._buttonNode = node)}
+      />
+    )
+  }
+}
+
+export default Button

--- a/src/button.js
+++ b/src/button.js
@@ -10,16 +10,13 @@ class Button extends Component {
   }
 
   static propTypes = {
-    disabled: PropTypes.bool,
     onKeyDown: PropTypes.func,
-    onClick: PropTypes.func,
   }
 
   constructor(props, context) {
     super(props, context)
     this.autocomplete = this.context[AUTOCOMPLETE_CONTEXT]
     this.handleKeyDown = compose(this.handleKeyDown, props.onKeyDown)
-    this.handleClick = compose(this.handleClick, props.onClick)
   }
 
   keyDownHandlers = {
@@ -66,23 +63,17 @@ class Button extends Component {
     this.autocomplete.toggleMenu()
   }
 
-  focusButton = () => {
-    this._buttonNode.focus()
-  }
-
   render() {
-    const {disabled, ...rest} = this.props
     const {isOpen} = this.autocomplete.state
     return (
       <button
         role="button"
-        tabIndex={disabled ? '' : '0'}
-        aria-haspopup={true}
+        aria-label={isOpen ? 'close menu' : 'open menu'}
         aria-expanded={isOpen}
-        aria-disabled={disabled}
-        {...rest}
-        onKeyDown={this.handleKeyDown}
+        aria-haspopup={true}
         onClick={this.handleClick}
+        {...this.props}
+        onKeyDown={this.handleKeyDown}
         ref={node => (this._buttonNode = node)}
       />
     )

--- a/src/input.js
+++ b/src/input.js
@@ -1,12 +1,13 @@
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 
-import {AUTOCOMPLETE_CONTEXT} from './constants'
+import {AUTOCOMPLETE_CONTEXT, MENU_CONTEXT} from './constants'
 import {compose} from './utils'
 
 class Input extends Component {
   static contextTypes = {
     [AUTOCOMPLETE_CONTEXT]: PropTypes.object.isRequired,
+    [MENU_CONTEXT]: PropTypes.object,
   }
   static ignoreKeys = ['Shift', 'Meta', 'Alt', 'Control']
   static propTypes = {
@@ -21,6 +22,7 @@ class Input extends Component {
   constructor(props, context) {
     super(props, context)
     this.autocomplete = this.context[AUTOCOMPLETE_CONTEXT]
+    this.autoFocus = typeof this.context[MENU_CONTEXT] !== 'undefined'
     this.autocomplete.input = this
     this.handleChange = compose(this.handleChange, this.props.onChange)
     this.handleKeyDown = compose(this.handleKeyDown, this.props.onKeyDown)
@@ -105,6 +107,7 @@ class Input extends Component {
         aria-expanded={isOpen}
         autoComplete="off"
         value={(inputValue === null ? selectedItemValue : inputValue) || ''}
+        autoFocus={this.autoFocus}
         {...rest}
         onChange={this.handleChange}
         onKeyDown={this.handleKeyDown}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
A `Button` component that applies proper ARIA attributes and allows controlling the opening and closing of the menu as well as keyboard navigation of the list of items.
<!-- Why are these changes necessary? -->
**Why**:
This helps us build accessible dropdown + autocomplete solutions.
<!-- How were these changes implemented? -->
**How**:
I added a `Button` component that mimics some of the behavior of the `Input`.
<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
Another addition to the API 😇 I think this will help with having an accessible button handy to control the `Menu`. I used it real quick in your semantic-ui demo and it worked nice 👌 applies all the proper ARIA attributes and allows for keyboard navigation.