### PR TITLE
add action prop to Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ This component renders a `button` tag and allows you to interact with the `Autoc
 
 #### action
 
-> `open` | `close` | `toggle` | `clearSelection` | defaults to `'toggle'`
+> `open`/`close`/`toggle`/`clearSelection` | defaults to `'toggle'`
 
 This allows you to specify what type of action the button should take when interacted with. It will take care of calling the proper `Autocomplete` method as well as apply an `aria-label` for you.
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ This allows you to specify what type of action the button should take when inter
 
 > `string`/`Component` | defaults to `'button'`
 
-This allows you to control what is rendered as the root element.
+This allows you to control what is rendered as the root element. This should allow you to use your own component. Please remember that for accessibility purposes, you should ultimately render a `button`. Anything else is probably inaccessible in this context.
 
 ### Autocomplete.Item
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Called when the user selects an item
 
 > `string`/`Component` | defaults to `'div'`
 
-This allows you to controll what is rendered as the root element.
+This allows you to control what is rendered as the root element.
 
 #### innerRef
 
@@ -187,7 +187,19 @@ This is called with an object with the properties listed below:
 
 ### Autocomplete.Button
 
-This component renders a `button` tag and allows you to toggle the `Menu` component. You can definitely build something like this yourself (all of the available APIs are exposed to you via the `Controller`), but this is nice because it will also apply all of the proper ARIA attributes.
+This component renders a `button` tag and allows you to interact with the `Autocomplete` component. You can definitely build something like this yourself (all of the available APIs are exposed to you via the `Controller`), but this is nice because it will also apply all of the proper ARIA attributes.
+
+#### action
+
+> `open` | `close` | `toggle` | `clearSelection` | defaults to `'toggle'`
+
+This allows you to specify what type of action the button should take when interacted with. It will take care of calling the proper `Autocomplete` method as well as apply an `aria-label` for you.
+
+#### component
+
+> `string`/`Component` | defaults to `'button'`
+
+This allows you to control what is rendered as the root element.
 
 ### Autocomplete.Item
 

--- a/examples/pages/semantic-ui/index.js
+++ b/examples/pages/semantic-ui/index.js
@@ -149,17 +149,11 @@ function SemanticUIAutocomplete() {
         {({isOpen, toggleMenu, clearSelection, selectedItem}) =>
           (<Div position="relative" css={{paddingRight: '1.75em'}}>
             <Input isOpen={isOpen} placeholder="Enter some info" />
-            {selectedItem
-              ? <ControllerButton
-                css={{paddingTop: 4}}
-                onClick={clearSelection}
-                aria-label="clear selection"
-                >
-                <XIcon />
-              </ControllerButton>
-              : <ControllerButton>
-                <ArrowIcon isOpen={isOpen} />
-              </ControllerButton>}
+            <ControllerButton
+              action={selectedItem ? 'clearSelection' : 'toggle'}
+            >
+              {selectedItem ? <XIcon /> : <ArrowIcon isOpen={isOpen} />}
+            </ControllerButton>
           </Div>)}
       </Autocomplete.Controller>
       <Autocomplete.Controller>
@@ -210,6 +204,7 @@ function XIcon() {
       fill="transparent"
       stroke="#979797"
       strokeWidth="1.1px"
+      style={{marginTop: 4}}
     >
       <path d="M1,1 L19,19" />
       <path d="M19,1 L1,19" />

--- a/src/button.js
+++ b/src/button.js
@@ -11,17 +11,38 @@ class Button extends Component {
 
   static propTypes = {
     component: PropTypes.any,
+    action: PropTypes.oneOf(['open', 'close', 'toggle', 'clearSelection']),
     onKeyDown: PropTypes.func,
   }
 
   static defaultProps = {
     component: 'button',
+    action: 'toggle',
   }
 
   constructor(props, context) {
     super(props, context)
     this.autocomplete = this.context[AUTOCOMPLETE_CONTEXT]
     this.handleKeyDown = compose(this.handleKeyDown, props.onKeyDown)
+  }
+
+  actionTypes = {
+    open: {
+      label: 'open menu',
+      action: () => this.autocomplete.openMenu(),
+    },
+    close: {
+      label: 'close menu',
+      action: () => this.autocomplete.closeMenu(),
+    },
+    toggle: {
+      label: isOpen => (isOpen ? 'close menu' : 'open menu'),
+      action: () => this.autocomplete.toggleMenu(),
+    },
+    clearSelection: {
+      label: 'clear selection',
+      action: () => this.autocomplete.clearSelection(),
+    },
   }
 
   keyDownHandlers = {
@@ -38,11 +59,13 @@ class Button extends Component {
     },
 
     Enter(event) {
-      event.preventDefault()
-      if (this.autocomplete.state.isOpen) {
-        this.autocomplete.selectHighlightedItem()
-      } else {
-        this.autocomplete.openMenu()
+      if (this.props.action !== 'clearSelection') {
+        event.preventDefault()
+        if (this.autocomplete.state.isOpen) {
+          this.autocomplete.selectHighlightedItem()
+        } else {
+          this.autocomplete.openMenu()
+        }
       }
     },
 
@@ -65,16 +88,17 @@ class Button extends Component {
 
   handleClick = event => {
     event.preventDefault()
-    this.autocomplete.toggleMenu()
+    this.actionTypes[this.props.action].action()
   }
 
   render() {
-    const {component: ButtonComponent, ...rest} = this.props
+    const {component: ButtonComponent, action, ...rest} = this.props
     const {isOpen} = this.autocomplete.state
+    const {label} = this.actionTypes[action]
     return (
       <ButtonComponent
         role="button"
-        aria-label={isOpen ? 'close menu' : 'open menu'}
+        aria-label={typeof label === 'function' ? label(isOpen) : label}
         aria-expanded={isOpen}
         aria-haspopup={true}
         onClick={this.handleClick}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
This adds an `action` prop to the `Button` component.
<!-- Why are these changes necessary? -->
**Why**:
After messing with the example I realized `clearSelection` didn't work and figured we should bake this in since there is some proper coordination that needs to go on with key handlers and click events. This also widens the pit of success for accessibility 🎉 
<!-- How were these changes implemented? -->
**How**:
I added a map of how each action should be handled and then call the respective action with the prop that was passed. I think after this we can explore even better accessibility and expose the labels for internationalization 😁 
<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
