### PR TITLE
Only return child function

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ node_modules
 coverage
 dist
 examples/other/react-autocompletely
+storybook-static

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ This is called with an object with the properties listed below:
 
 | property                | type                       | description                                                                                                      |
 |-------------------------|----------------------------|------------------------------------------------------------------------------------------------------------------|
+| `getRootProps`          | `function({})`             | returns the props you should apply to the root element that you render. It can be optional. Read more below      |
 | `getInputProps`         | `function({})`             | returns the props you should apply to the `input` element that you render. Read more below                       |
 | `getItemProps`          | `function({})`             | returns the props you should apply to any menu item elements you render. Read more below                         |
 | `getButtonProps`        | `function({})`             | returns the props you should apply to any menu toggle button element you render. Read more below                 |
@@ -177,6 +178,29 @@ This is called with an object with the properties listed below:
 | `selectItemAtIndex`     | `function(index: number)`  | selects the item at the given index                                                                              |
 | `selectHighlightedItem` | `function()`               | selects the item that is currently highlighted                                                                   |
 
+The functions below are used to apply props to the elements that you render.
+This gives you maximum flexibility to render what, when, and wherever you like.
+You call these on the element in question (for example:
+`<input {...getInputProps()}`)). It's advisable to pass all your props to that
+function rather than applying them on the element yourself to avoid your props
+being overridden (or overriding the props returned). For example:
+`getInputProps({onKeyUp(event) {console.log(event)}})`.
+
+##### `getRootProps`
+
+Most of the time, you can just render a `div` yourself and `Autocompletely` will
+apply the props it needs to do its job (and you don't need to call this
+function). However, if you're rendering a composite component (custom component)
+as the root element, then you'll need to call `getRootProps` and apply that to
+your root element.
+
+Required properties:
+
+- `refKey`: if you're rendering a composite component, that component will need
+  to accept a prop which it forwards to the root DOM element. Commonly, folks
+  call this `innerRef`. So you'd call: `getRootProps({refKey: 'innerRef'})`
+  and your composite component would forward like: `<div ref={props.innerRef} />`
+
 ##### `getInputProps`
 
 This method should be applied to the `input` you render. It is recommended that
@@ -190,9 +214,13 @@ There are no required properties for this method.
 
 This method should be applied to any menu items you render. You pass it an object
 and that object must contain `index` (number) and `value` (anything) properties.
-The `index` is how `react-autocompletely` keeps track of your item when updating
-the `highlightedIndex` as the user keys around. The `value` property is the item
-data that will be selected when the user selects a particular item.
+
+Required properties:
+
+- `index`: this is how `react-autocompletely` keeps track of your item when
+  updating the `highlightedIndex` as the user keys around.
+- `value`: this is the item data that will be selected when the user selects a
+  particular item.
 
 ##### `getButtonProps`
 

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -1,6 +1,6 @@
 /* eslint camelcase:0 */
 
-import React, {Component} from 'react'
+import {Component} from 'react'
 import PropTypes from 'prop-types'
 import setA11yStatus from './set-a11y-status'
 import {cbToCb, composeEventHandlers, debounce, scrollIntoView} from './utils'
@@ -174,6 +174,7 @@ class Autocomplete extends Component {
       selectItemAtIndex,
       selectHighlightedItem,
       setHighlightedIndex,
+      getRootProps,
       getButtonProps,
       getInputProps,
       getItemProps,
@@ -191,6 +192,7 @@ class Autocomplete extends Component {
       openMenu,
       closeMenu,
       clearSelection,
+      getRootProps,
       getButtonProps,
       getInputProps,
       getItemProps,
@@ -200,7 +202,16 @@ class Autocomplete extends Component {
   //////////////////////////// ROOT
 
   rootRef = node => (this._rootNode = node)
-  handleClick = event => {
+
+  getRootProps = ({refKey = 'ref', onClick, ...rest} = {}) => {
+    return {
+      [refKey]: this.rootRef,
+      onClick: composeEventHandlers(onClick, this.root_handleClick),
+      ...rest,
+    }
+  }
+
+  root_handleClick = event => {
     event.preventDefault()
     const {target} = event
     if (!target) {
@@ -420,25 +431,8 @@ class Autocomplete extends Component {
     // because the items are rerendered every time we call the children
     // we clear this out each render and
     this.items = []
-    const {
-      children,
-      // eslint-disable-next-line no-unused-vars
-      defaultSelectedItem,
-      // eslint-disable-next-line no-unused-vars
-      getValue,
-      // eslint-disable-next-line no-unused-vars
-      getA11yStatusMessage,
-      // eslint-disable-next-line no-unused-vars
-      defaultHighlightedIndex,
-      // eslint-disable-next-line no-unused-vars
-      onChange,
-      ...rest
-    } = this.props
-    return (
-      <div {...rest} ref={this.rootRef} onClick={this.handleClick}>
-        {children(this.getControllerStateAndHelpers())}
-      </div>
-    )
+    const {children} = this.props
+    return children(this.getControllerStateAndHelpers())
   }
 }
 

--- a/stories/config.js
+++ b/stories/config.js
@@ -13,7 +13,7 @@ import Popper from './examples/react-popper'
 
 function loadStories() {
   // clear the console to make debugging experience better
-  setTimeout(() => console.clear(), 100)
+  console.clear()
 
   storiesOf('Examples', module)
     .add('basic', () => <Basic />)

--- a/stories/examples/basic.js
+++ b/stories/examples/basic.js
@@ -71,7 +71,7 @@ const Item = glamorous.div(
       borderColor: '#96c8da',
       boxShadow: '0 2px 3px 0 rgba(34,36,38,.15)',
     },
-  })
+  }),
 )
 
 const Input = glamorous.input({
@@ -96,18 +96,25 @@ const Input = glamorous.input({
   },
 })
 
+// this is just a demo of how you'd use the getRootProps function
+// normally you wouldn't need this kind of abstraction 😉
+function Root({innerRef, ...rest}) {
+  return <div ref={innerRef} {...rest} />
+}
+
 function BasicAutocomplete({items, onChange}) {
   return (
     <Autocomplete onChange={onChange}>
       {({
         getInputProps,
         getItemProps,
+        getRootProps,
         isOpen,
         value,
         selectedItem,
         highlightedIndex,
       }) =>
-        (<div>
+        (<Root {...getRootProps({refKey: 'innerRef'})}>
           <Input {...getInputProps({placeholder: 'Favorite color ?'})} />
           {isOpen &&
             <div style={{border: '1px solid rgba(34,36,38,.15)'}}>
@@ -122,10 +129,10 @@ function BasicAutocomplete({items, onChange}) {
                   })}
                 >
                   {item}
-                </Item>)
+                </Item>),
               )}
             </div>}
-        </div>)}
+        </Root>)}
     </Autocomplete>
   )
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Removes the last opinion about the DOM. 
<!-- Why are these changes necessary? -->
**Why**:
I already hit a snag where I wanted a custom top level component to integrate better in my UI kit and I think this might be better since it follows suite to the other functions like `getItemProps`.
<!-- How were these changes implemented? -->
**How**:
I was able to get around the `ref` issue by just allowing a prop called `refKey` to be passed when you need to forward the ref in a non-traditional way like `{ refKey: 'innerRef' }`. I'm not tied to the name of the prop, maybe `getRef` or something? After doing this I'm wondering if we can go back to just using refs for the other components. It's up to you though :)
<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
